### PR TITLE
Share one SSO session across MangaLib and HentaiLib

### DIFF
--- a/index.json
+++ b/index.json
@@ -16,7 +16,8 @@
         "protectorConfig": {
           "pingUrl": "https://hentailib.me/manga-list",
           "needToLogin": true,
-          "inAppBrowserInterceptor": true
+          "inAppBrowserInterceptor": true,
+          "sessionGroup": "lib_social"
         },
         "searchAvailable": true
       }
@@ -72,7 +73,8 @@
         "protectorConfig": {
           "pingUrl": "https://mangalib.me/manga-list",
           "needToLogin": true,
-          "inAppBrowserInterceptor": true
+          "inAppBrowserInterceptor": true,
+          "sessionGroup": "lib_social"
         },
         "searchAvailable": true
       }

--- a/manga/hentai_lib/config.json
+++ b/manga/hentai_lib/config.json
@@ -10,7 +10,8 @@
   "protectorConfig": {
     "pingUrl": "https://hentailib.me/manga-list",
     "needToLogin": true,
-    "inAppBrowserInterceptor": true
+    "inAppBrowserInterceptor": true,
+    "sessionGroup": "lib_social"
   },
   "searchAvailable": true
 }

--- a/manga/manga_lib/config.json
+++ b/manga/manga_lib/config.json
@@ -10,7 +10,8 @@
   "protectorConfig": {
     "pingUrl": "https://mangalib.me/manga-list",
     "needToLogin": true,
-    "inAppBrowserInterceptor": true
+    "inAppBrowserInterceptor": true,
+    "sessionGroup": "lib_social"
   },
   "searchAvailable": true
 }


### PR DESCRIPTION
Add sessionGroup lib_social to the Lib-family protector configs so a login on one is reused by the other.